### PR TITLE
Force email format to downcase

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1221,3 +1221,7 @@ RSpec/FilePath:
   Exclude:
     - "spec/omniauth/strategies/publik_spec.rb"
 # This is the default configuration file.
+
+RSpec/VerifiedDoubleReference:
+  Exclude:
+    - "spec/omniauth/strategies/publik_spec.rb"

--- a/lib/omniauth/strategies/publik.rb
+++ b/lib/omniauth/strategies/publik.rb
@@ -24,7 +24,7 @@ module OmniAuth
 
       info do
         {
-          email: raw_info["email"] || "",
+          email: raw_info["email"]&.downcase || "",
           nickname: parse_nickname,
           name: parse_name
         }

--- a/spec/omniauth/strategies/publik_spec.rb
+++ b/spec/omniauth/strategies/publik_spec.rb
@@ -307,6 +307,14 @@ describe OmniAuth::Strategies::Publik do
           expect(subject.info[:email]).to be_empty
         end
       end
+
+      context "when 'email' is uppercase" do
+        let(:email) { "FOO+EXAMPLE@example.com" }
+
+        it "returns downcased email" do
+          expect(subject.info[:email]).to eq("foo+example@example.com")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
* Update gemspec

* Git ignore '.byebug_history'

* Fix tests

* Refactor raw_info specs

* Enhance tests for 'given_name' key

* Add tests for 'email' key

* Update rubocop rules

* Fix rubocop offenses

* Remove unnecessary '.byebug_history' file

* Raise error when site param is undefined or empty

* Check errors

* Add Github Actions workflows

* Bump bundler version

* Bump bundler version

* Fix rubocop offense

* Move 'byebug' requirement